### PR TITLE
Implement analytics.tracking marketing analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,23 @@ NEXT_PUBLIC_CUSTOMER_PORTAL_URL=https://cutrateslawn.fieldportals.com/landing/in
 # --- Social (optional — used in layout metadata) -------------------------------
 NEXT_PUBLIC_TWITTER_HANDLE=@cutratelawn
 
-# --- Analytics (optional — add when you connect Google Analytics) --------------
-# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+# --- Analytics (optional — analytics.tracking@v1.0.0; unset = silent no-op) ---
+# Never hardcode real account IDs in source. Create accounts in GA4/Ads/Meta/GTM,
+# then set these locally / in Vercel / GitHub secrets.
+# NEXT_PUBLIC_GTM_CONTAINER_ID=GTM-XXXXXXX
+# NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-XXXXXXXXXX
+# NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_ID=AW-XXXXXXXXXX
+# NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABEL=
+# NEXT_PUBLIC_META_PIXEL_ID=
+# Weekly report (server/CI only — fails loudly with HUMAN SETUP callout if unset):
+# GA4_PROPERTY_ID=
+# GA4_DATA_API_CREDENTIALS_JSON=
+# WEEKLY_REPORT_EMAIL_TO=
+# WEEKLY_REPORT_EMAIL_FROM=
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASS=
 
 # --- Form submissions / leads --------------------------------------------------
 # At least one delivery channel required for contact success (else API returns 503).

--- a/.github/workflows/analytics-weekly-report.yml
+++ b/.github/workflows/analytics-weekly-report.yml
@@ -1,0 +1,33 @@
+name: analytics-weekly-report
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Pull GA4 weekly metrics (credential-gated)
+        env:
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+          GA4_DATA_API_CREDENTIALS_JSON: ${{ secrets.GA4_DATA_API_CREDENTIALS_JSON }}
+          WEEKLY_REPORT_EMAIL_TO: ${{ secrets.WEEKLY_REPORT_EMAIL_TO }}
+          WEEKLY_REPORT_EMAIL_FROM: ${{ secrets.WEEKLY_REPORT_EMAIL_FROM }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+        run: node scripts/analytics/weekly-report.mjs
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-analytics-report
+          path: artifacts/weekly-analytics-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/capability-drift.yml
+++ b/.github/workflows/capability-drift.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/capability-drift.yml
+++ b/.github/workflows/capability-drift.yml
@@ -1,0 +1,27 @@
+name: capability-drift
+
+on:
+  pull_request:
+    paths:
+      - 'CAPABILITIES.lock'
+      - 'vendor/capabilities/**'
+      - 'lib/analytics/**'
+      - 'scripts/analytics/**'
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Offline analytics.tracking conformance
+        run: node scripts/analytics/conformance-check.mjs
+      - name: Lock integrity present
+        run: test -f vendor/capabilities/analytics.tracking/conformance/suite.json

--- a/CAPABILITIES.lock
+++ b/CAPABILITIES.lock
@@ -1,0 +1,8 @@
+schema_version: 1
+registry: xoate0100/capability-registry
+updated: '2026-09-02'
+capabilities:
+- capability_id: analytics.tracking
+  git_tag: capability/analytics.tracking/v1.0.0
+  integrity: sha256-1c8309c6196d4a0330a05c11697c4f02e0b24837fccac77234e6be4eb81ad455
+  vendored_path: vendor/capabilities/analytics.tracking

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import { Toaster } from "@/components/ui/sonner"
 import { siteConfig } from "@/lib/site-config"
 import { mediaSrc } from "@/lib/media"
 import { Providers } from "./providers"
+import { GtmNoScript, GtmScript } from "@/components/analytics/gtm-script"
 
 const LiveChat = dynamic(() => import("@/components/live-chat"), { ssr: false })
 
@@ -94,6 +95,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${display.variable} ${body.variable} font-body`}>
+        <GtmScript />
+        <GtmNoScript />
         <Providers>
           <AnnouncementMarquee />
           <SiteHeader />

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,7 +1,9 @@
 "use client"
 
 import type React from "react"
+import { Suspense } from "react"
 
+import { AnalyticsProvider } from "@/components/analytics/analytics-provider"
 import { ThemeProvider } from "@/components/theme-provider"
 import { ReviewsProvider } from "@/contexts/reviews-context"
 import { AuthProvider } from "@/contexts/auth-context"
@@ -10,7 +12,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="light">
       <AuthProvider>
-        <ReviewsProvider>{children}</ReviewsProvider>
+        <ReviewsProvider>
+          <Suspense fallback={null}>
+            <AnalyticsProvider>{children}</AnalyticsProvider>
+          </Suspense>
+        </ReviewsProvider>
       </AuthProvider>
     </ThemeProvider>
   )

--- a/app/service-areas/[slug]/page.tsx
+++ b/app/service-areas/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   SERVICES,
   testimonialsForArea,
 } from "@/lib/marketing-content"
+import { AreaViewTracker } from "@/components/analytics/area-view-tracker"
 
 type Props = { params: { slug: string } }
 
@@ -37,6 +38,7 @@ export default function ServiceAreaSlugPage({ params }: Props) {
 
   return (
     <div className="bg-paper">
+      <AreaViewTracker areaSlug={area.slug} areaName={area.name} />
       <InteriorHero
         eyebrow={`${area.name} · KS`}
         title={`Lawn care & landscaping in ${area.name}.`}

--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation"
 import { ServiceDetailView } from "@/components/blocks"
+import { ServiceViewTracker } from "@/components/analytics/service-view-tracker"
 import { getServiceDetail, getServiceSlugs } from "@/lib/marketing-content"
 
 type Props = { params: { slug: string } }
@@ -20,5 +21,10 @@ export function generateMetadata({ params }: Props) {
 export default function ServiceSlugPage({ params }: Props) {
   const detail = getServiceDetail(params.slug)
   if (!detail) notFound()
-  return <ServiceDetailView detail={detail} />
+  return (
+    <>
+      <ServiceViewTracker serviceId={detail.id} serviceName={detail.title} />
+      <ServiceDetailView detail={detail} />
+    </>
+  )
 }

--- a/components/analytics/analytics-provider.tsx
+++ b/components/analytics/analytics-provider.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+import { initAnalyticsCapture, trackPageView } from "@/lib/analytics/core"
+
+/** Initializes attribution capture + page_view on route changes. */
+export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    initAnalyticsCapture()
+  }, [])
+
+  useEffect(() => {
+    trackPageView()
+  }, [pathname, searchParams])
+
+  return <>{children}</>
+}

--- a/components/analytics/area-view-tracker.tsx
+++ b/components/analytics/area-view-tracker.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useEffect } from "react"
+import { trackAreaView } from "@/lib/analytics/core"
+
+export function AreaViewTracker({
+  areaSlug,
+  areaName,
+}: {
+  areaSlug: string
+  areaName: string
+}) {
+  useEffect(() => {
+    trackAreaView(areaSlug, areaName)
+  }, [areaSlug, areaName])
+  return null
+}

--- a/components/analytics/gtm-script.tsx
+++ b/components/analytics/gtm-script.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import Script from "next/script"
+import { analyticsConfig } from "@/lib/analytics/config"
+
+/** Loads GTM only when NEXT_PUBLIC_GTM_CONTAINER_ID is set. */
+export function GtmScript() {
+  const id = analyticsConfig.gtmContainerId
+  if (!id) return null
+
+  return (
+    <>
+      <Script id="gtm-init" strategy="afterInteractive">
+        {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${id}');`}
+      </Script>
+    </>
+  )
+}
+
+export function GtmNoScript() {
+  const id = analyticsConfig.gtmContainerId
+  if (!id) return null
+  return (
+    <noscript>
+      <iframe
+        src={`https://www.googletagmanager.com/ns.html?id=${id}`}
+        height="0"
+        width="0"
+        style={{ display: "none", visibility: "hidden" }}
+        title="Google Tag Manager"
+      />
+    </noscript>
+  )
+}

--- a/components/analytics/phone-link.tsx
+++ b/components/analytics/phone-link.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { trackPhoneClick } from "@/lib/analytics/core"
+
+export function AnalyticsPhoneLink({
+  href,
+  location,
+  className,
+  children,
+}: {
+  href: string
+  location: string
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <a
+      href={href}
+      className={className}
+      onClick={() => trackPhoneClick(location)}
+    >
+      {children}
+    </a>
+  )
+}

--- a/components/analytics/service-view-tracker.tsx
+++ b/components/analytics/service-view-tracker.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useEffect } from "react"
+import { trackServiceView } from "@/lib/analytics/core"
+
+export function ServiceViewTracker({
+  serviceId,
+  serviceName,
+}: {
+  serviceId: string
+  serviceName: string
+}) {
+  useEffect(() => {
+    trackServiceView(serviceId, serviceName)
+  }, [serviceId, serviceName])
+  return null
+}

--- a/components/blocks/site-header.tsx
+++ b/components/blocks/site-header.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { pageWrap } from "@/lib/layout"
 import { NAV_LINKS } from "@/lib/marketing-content"
 import { siteConfig } from "@/lib/site-config"
+import { trackPhoneClick } from "@/lib/analytics/core"
 import { cn } from "@/lib/utils"
 
 export function SiteHeader() {
@@ -47,6 +48,7 @@ export function SiteHeader() {
         <a
           href={`tel:${siteConfig.phone.e164}`}
           className="hidden font-bold text-[0.9rem] opacity-90 lg:inline"
+          onClick={() => trackPhoneClick("header_desktop")}
         >
           {siteConfig.phone.display}
         </a>
@@ -85,7 +87,11 @@ export function SiteHeader() {
                 {link.label}
               </Link>
             ))}
-            <a href={`tel:${siteConfig.phone.e164}`} className="py-2 font-bold">
+            <a
+              href={`tel:${siteConfig.phone.e164}`}
+              className="py-2 font-bold"
+              onClick={() => trackPhoneClick("header_mobile")}
+            >
               {siteConfig.phone.display}
             </a>
             <Button asChild variant="lime" className="mt-2 w-full">

--- a/components/quote/quote-funnel.tsx
+++ b/components/quote/quote-funnel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState, type FormEvent } from "react"
+import { useMemo, useState, useEffect, type FormEvent } from "react"
 import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
@@ -19,6 +19,7 @@ import {
   type PropertyType,
   type ServiceType,
 } from "@/lib/pricing/estimate"
+import { useAnalytics } from "@/hooks/useAnalytics"
 
 type Step = "details" | "estimate" | "contact" | "done"
 
@@ -54,6 +55,7 @@ function newIdempotencyKey() {
 
 export function QuoteFunnel() {
   const searchParams = useSearchParams()
+  const { onFunnelStep, onConversionLead } = useAnalytics()
   const [step, setStep] = useState<Step>("details")
   const [propertyType, setPropertyType] = useState<PropertyType>("residential")
   const [serviceType, setServiceType] = useState<ServiceType | "">(() =>
@@ -85,6 +87,16 @@ export function QuoteFunnel() {
     if (step === "contact") return 3
     return 4
   }, [step])
+
+  useEffect(() => {
+    const stepNames: Record<Step, string> = {
+      details: "details",
+      estimate: "estimate",
+      contact: "contact",
+      done: "done",
+    }
+    onFunnelStep("quote", stepNames[step], stepIndex)
+  }, [step, stepIndex, onFunnelStep])
 
   const calculateQuote = () => {
     const outcome = calculateEstimate({
@@ -162,6 +174,11 @@ export function QuoteFunnel() {
         return
       }
       setStep("done")
+      onConversionLead(
+        data.requestId ?? idempotencyKey,
+        quote.amount,
+        "USD",
+      )
       setIdempotencyKey(newIdempotencyKey())
     } catch {
       setSubmitError(`Network error. Please call ${siteConfig.phone.display}.`)

--- a/docs/CAPABILITY_PILOT.md
+++ b/docs/CAPABILITY_PILOT.md
@@ -1,0 +1,24 @@
+# analytics.tracking on CutRatesLawnWebSite
+
+| Field | Value |
+|---|---|
+| Capability | `analytics.tracking@v1.0.0` |
+| Lock | `CAPABILITIES.lock` |
+| Vendor | `vendor/capabilities/analytics.tracking/` |
+| Provider | `lib/analytics/` |
+| Conformance | `pnpm analytics:conformance` |
+| Weekly report | `pnpm analytics:weekly-report` (Mondays via GitHub Action) |
+
+## Env vars (all optional — unset = no-op)
+
+| Variable | Purpose |
+|---|---|
+| `NEXT_PUBLIC_GTM_CONTAINER_ID` | GTM container |
+| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | GA4 via GTM |
+| `NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_ID` | Ads conversion |
+| `NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABEL` | Ads conversion label |
+| `NEXT_PUBLIC_META_PIXEL_ID` | Meta via GTM |
+| `GA4_PROPERTY_ID` | Weekly report property |
+| `GA4_DATA_API_CREDENTIALS_JSON` | Service account JSON for Data API |
+
+See `docs/factory/ANALYTICS_TRACKING_REPORT.md` in project_initializer for human setup steps.

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -1,0 +1,46 @@
+"use client"
+
+import { useCallback } from "react"
+import {
+  trackAreaView,
+  trackConversionLead,
+  trackFunnelStep,
+  trackPhoneClick,
+  trackServiceView,
+} from "@/lib/analytics/core"
+
+export function useAnalytics() {
+  const onServiceView = useCallback((serviceId: string, serviceName: string) => {
+    trackServiceView(serviceId, serviceName)
+  }, [])
+
+  const onAreaView = useCallback((areaSlug: string, areaName: string) => {
+    trackAreaView(areaSlug, areaName)
+  }, [])
+
+  const onFunnelStep = useCallback(
+    (funnelId: string, stepName: string, stepNumber: number) => {
+      trackFunnelStep(funnelId, stepName, stepNumber)
+    },
+    [],
+  )
+
+  const onPhoneClick = useCallback((location: string) => {
+    trackPhoneClick(location)
+  }, [])
+
+  const onConversionLead = useCallback(
+    (transactionId: string, conversionValue: number, currency = "USD") => {
+      trackConversionLead({ transactionId, conversionValue, currency })
+    },
+    [],
+  )
+
+  return {
+    onServiceView,
+    onAreaView,
+    onFunnelStep,
+    onPhoneClick,
+    onConversionLead,
+  }
+}

--- a/lib/analytics/config.ts
+++ b/lib/analytics/config.ts
@@ -1,0 +1,44 @@
+/**
+ * Env-gated analytics platform IDs. Unset → no-op silently.
+ */
+function readEnv(key: string): string | undefined {
+  const v = process.env[key]
+  if (!v || !v.trim()) return undefined
+  return v.trim()
+}
+
+export const analyticsConfig = {
+  gtmContainerId: readEnv("NEXT_PUBLIC_GTM_CONTAINER_ID"),
+  ga4MeasurementId: readEnv("NEXT_PUBLIC_GA4_MEASUREMENT_ID"),
+  googleAdsConversionId: readEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_ID"),
+  googleAdsConversionLabel: readEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABEL"),
+  metaPixelId: readEnv("NEXT_PUBLIC_META_PIXEL_ID"),
+} as const
+
+export function isAnalyticsEnabled(): boolean {
+  return Boolean(analyticsConfig.gtmContainerId)
+}
+
+export function configuredDestinations(): Record<string, string | undefined> {
+  return {
+    ga4: analyticsConfig.ga4MeasurementId,
+    google_ads: analyticsConfig.googleAdsConversionId,
+    meta_pixel: analyticsConfig.metaPixelId,
+  }
+}
+
+/** Server-side weekly report credentials (never exposed to client). */
+export const reportConfig = {
+  ga4PropertyId: readEnv("GA4_PROPERTY_ID"),
+  credentialsJson: readEnv("GA4_DATA_API_CREDENTIALS_JSON"),
+  emailTo: readEnv("WEEKLY_REPORT_EMAIL_TO"),
+  emailFrom: readEnv("WEEKLY_REPORT_EMAIL_FROM"),
+  smtpHost: readEnv("SMTP_HOST"),
+  smtpPort: readEnv("SMTP_PORT"),
+  smtpUser: readEnv("SMTP_USER"),
+  smtpPass: readEnv("SMTP_PASS"),
+  monthlyLineItemUsd: 449,
+} as const
+
+export const HUMAN_SETUP_CALLOUT =
+  "HUMAN SETUP: Set GA4_PROPERTY_ID and GA4_DATA_API_CREDENTIALS_JSON (service account JSON with Analytics Data API read access on the GA4 property) to enable the weekly report."

--- a/lib/analytics/conformance-provider.mjs
+++ b/lib/analytics/conformance-provider.mjs
@@ -1,0 +1,121 @@
+/**
+ * Conformance provider — mirrors Python AnalyticsTrackingImpl for offline suite execution.
+ */
+const ATTRIBUTION_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+]
+
+const CONVERSION_EVENTS = new Set(["conversion_lead", "lead_conversion", "conversion"])
+
+function mergeAttribution(event, stored, url) {
+  const merged = {}
+  for (const src of [stored || {}, url || {}]) {
+    for (const k of ATTRIBUTION_KEYS) {
+      if (src[k]) merged[k] = src[k]
+    }
+  }
+  for (const k of ATTRIBUTION_KEYS) {
+    if (event[k]) merged[k] = event[k]
+  }
+  return merged
+}
+
+function hasAttribution(attribution) {
+  return Boolean(attribution.utm_source || attribution.gclid)
+}
+
+function notifyDestinations(destinations) {
+  if (!destinations) return []
+  const notified = []
+  for (const key of ["ga4", "google_ads", "meta_pixel"]) {
+    if (destinations[key]) notified.push(key)
+  }
+  return notified
+}
+
+export class AnalyticsTrackingProvider {
+  run(caseInput) {
+    const event = { ...(caseInput.event || {}) }
+    if (!event.event || !event.page_path) {
+      return { outcome: "reject", error_code: "EVENT_SCHEMA_INVALID" }
+    }
+
+    const name = String(event.event)
+    const attribution = mergeAttribution(
+      event,
+      caseInput.stored_attribution,
+      caseInput.url_attribution,
+    )
+
+    if (CONVERSION_EVENTS.has(name)) {
+      if (!event.transaction_id) {
+        return { outcome: "reject", error_code: "CONVERSION_ID_REQUIRED" }
+      }
+      if (event.conversion_value == null) {
+        return { outcome: "reject", error_code: "CONVERSION_VALUE_REQUIRED" }
+      }
+      if (!hasAttribution(attribution)) {
+        return { outcome: "reject", error_code: "ATTRIBUTION_REQUIRED" }
+      }
+    }
+
+    const enriched = {
+      ...event,
+      ...Object.fromEntries(Object.entries(attribution).filter(([, v]) => v)),
+    }
+    if (!enriched.timestamp) enriched.timestamp = Date.now()
+
+    return {
+      outcome: "pass",
+      datalayer_push: enriched,
+      attribution_captured: hasAttribution(attribution),
+      destinations_notified: notifyDestinations(caseInput.destinations),
+    }
+  }
+}
+
+export class BrokenAnalyticsTrackingProvider {
+  run(caseInput) {
+    const event = { ...(caseInput.event || {}) }
+    if (!event.event || !event.page_path) {
+      return { outcome: "reject", error_code: "EVENT_SCHEMA_INVALID" }
+    }
+
+    const name = String(event.event)
+    if (CONVERSION_EVENTS.has(name)) {
+      if (!event.transaction_id) {
+        return { outcome: "reject", error_code: "CONVERSION_ID_REQUIRED" }
+      }
+      if (event.conversion_value == null) {
+        return { outcome: "reject", error_code: "CONVERSION_VALUE_REQUIRED" }
+      }
+      return {
+        outcome: "pass",
+        datalayer_push: event,
+        attribution_captured: false,
+        destinations_notified: [],
+      }
+    }
+
+    const attribution = mergeAttribution(
+      event,
+      caseInput.stored_attribution,
+      caseInput.url_attribution,
+    )
+    const enriched = {
+      ...event,
+      ...Object.fromEntries(Object.entries(attribution).filter(([, v]) => v)),
+    }
+    return {
+      outcome: "pass",
+      datalayer_push: enriched,
+      attribution_captured: hasAttribution(attribution),
+      destinations_notified: notifyDestinations(caseInput.destinations),
+    }
+  }
+}

--- a/lib/analytics/core.ts
+++ b/lib/analytics/core.ts
@@ -1,0 +1,173 @@
+import {
+  analyticsConfig,
+  configuredDestinations,
+  isAnalyticsEnabled,
+} from "./config"
+import {
+  getStoredAttribution,
+  getUtmParams,
+  gtmEvent,
+  storePaidClickParams,
+} from "./gtm"
+import {
+  ATTRIBUTION_KEYS,
+  CONVERSION_EVENTS,
+  type AnalyticsEvent,
+  type AttributionParams,
+} from "./types"
+
+function mergeAttribution(
+  event: Record<string, unknown>,
+  stored: AttributionParams,
+  url: AttributionParams,
+): AttributionParams {
+  const merged: AttributionParams = {}
+  for (const src of [stored, url]) {
+    for (const k of ATTRIBUTION_KEYS) {
+      const v = src[k]
+      if (v) merged[k] = v
+    }
+  }
+  for (const k of ATTRIBUTION_KEYS) {
+    const v = event[k] as string | undefined
+    if (v) merged[k] = v
+  }
+  return merged
+}
+
+function hasAttribution(attribution: AttributionParams): boolean {
+  return Boolean(attribution.utm_source || attribution.gclid)
+}
+
+function notifyDestinations(): string[] {
+  const dest = configuredDestinations()
+  return (Object.entries(dest) as [string, string | undefined][])
+    .filter(([, v]) => Boolean(v))
+    .map(([k]) => k)
+}
+
+function getDeviceType(): "desktop" | "mobile" | "tablet" | undefined {
+  if (typeof window === "undefined" || !window.navigator) return undefined
+  const ua = window.navigator.userAgent.toLowerCase()
+  if (/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i.test(ua)) return "tablet"
+  if (/mobile|android|ip(hone|od)|iemobile|blackberry|kindle|silk-accelerated|(hpw|web)os|opera m(obi|ini)/i.test(ua)) {
+    return "mobile"
+  }
+  return "desktop"
+}
+
+function sessionId(): string | undefined {
+  if (typeof window === "undefined") return undefined
+  const key = "analytics_session_id"
+  let id = sessionStorage.getItem(key)
+  if (!id) {
+    id = `session_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+    sessionStorage.setItem(key, id)
+  }
+  return id
+}
+
+/** Runtime emit — validates, enriches, pushes to dataLayer. No-op when GTM unset. */
+export function pushAnalyticsEvent(event: AnalyticsEvent): boolean {
+  if (typeof window === "undefined") return false
+  if (!isAnalyticsEnabled()) return false
+
+  if (!event.event || !event.page_path) return false
+
+  const stored = getStoredAttribution()
+  const url = getUtmParams()
+  const attribution = mergeAttribution(event as Record<string, unknown>, stored, url)
+
+  if (CONVERSION_EVENTS.has(event.event) && !hasAttribution(attribution)) {
+    return false
+  }
+
+  const enriched = {
+    ...event,
+    timestamp: event.timestamp ?? Date.now(),
+    page_title: event.page_title ?? document.title,
+    page_location: event.page_location ?? window.location.href,
+    session_id: event.session_id ?? sessionId(),
+    device_type: event.device_type ?? getDeviceType(),
+    ...Object.fromEntries(Object.entries(attribution).filter(([, v]) => v)),
+    destinations_configured: notifyDestinations(),
+  }
+
+  gtmEvent(event.event, enriched)
+  return true
+}
+
+export function initAnalyticsCapture(): void {
+  if (typeof window === "undefined") return
+  storePaidClickParams()
+}
+
+export function trackPageView(pageTitle?: string): void {
+  if (typeof window === "undefined") return
+  pushAnalyticsEvent({
+    event: "page_view",
+    page_path: window.location.pathname,
+    page_title: pageTitle ?? document.title,
+  })
+}
+
+export function trackServiceView(serviceId: string, serviceName: string): void {
+  if (typeof window === "undefined") return
+  pushAnalyticsEvent({
+    event: "service_view",
+    page_path: window.location.pathname,
+    service_id: serviceId,
+    service_name: serviceName,
+  })
+}
+
+export function trackAreaView(areaSlug: string, areaName: string): void {
+  if (typeof window === "undefined") return
+  pushAnalyticsEvent({
+    event: "area_view",
+    page_path: window.location.pathname,
+    area_slug: areaSlug,
+    area_name: areaName,
+  })
+}
+
+export function trackFunnelStep(
+  funnelId: string,
+  stepName: string,
+  stepNumber: number,
+): void {
+  if (typeof window === "undefined") return
+  pushAnalyticsEvent({
+    event: "funnel_step_view",
+    page_path: window.location.pathname,
+    funnel_id: funnelId,
+    step_name: stepName,
+    step_number: stepNumber,
+  })
+}
+
+export function trackPhoneClick(location: string): void {
+  if (typeof window === "undefined") return
+  pushAnalyticsEvent({
+    event: "phone_click",
+    page_path: window.location.pathname,
+    click_location: location,
+  })
+}
+
+export function trackConversionLead(params: {
+  transactionId: string
+  conversionValue: number
+  currency?: string
+}): void {
+  if (typeof window === "undefined") return
+  pushAnalyticsEvent({
+    event: "conversion_lead",
+    page_path: window.location.pathname,
+    transaction_id: params.transactionId,
+    conversion_value: params.conversionValue,
+    currency: params.currency ?? "USD",
+  })
+}
+
+export { analyticsConfig, isAnalyticsEnabled }

--- a/lib/analytics/gtm.ts
+++ b/lib/analytics/gtm.ts
@@ -1,0 +1,93 @@
+import type { AttributionParams } from "./types"
+
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[]
+    google_tag_manager?: unknown
+  }
+}
+
+export function getUtmParams(): AttributionParams {
+  if (typeof window === "undefined") return {}
+  const searchParams = new URLSearchParams(window.location.search)
+  return {
+    utm_source: searchParams.get("utm_source") || undefined,
+    utm_medium: searchParams.get("utm_medium") || undefined,
+    utm_campaign: searchParams.get("utm_campaign") || undefined,
+    utm_term: searchParams.get("utm_term") || undefined,
+    utm_content: searchParams.get("utm_content") || undefined,
+  }
+}
+
+export function getGclid(): string | undefined {
+  if (typeof window === "undefined") return undefined
+  return new URLSearchParams(window.location.search).get("gclid") || undefined
+}
+
+export function storeUtmParams(): void {
+  if (typeof window === "undefined") return
+  const utmParams = getUtmParams()
+  if (utmParams.utm_source) {
+    sessionStorage.setItem("utm_params", JSON.stringify(utmParams))
+  }
+}
+
+export function storeGclid(): void {
+  if (typeof window === "undefined") return
+  const gclid = getGclid()
+  if (gclid) sessionStorage.setItem("gclid", gclid)
+}
+
+/** Capture UTM and gclid from URL on first page load of paid journey. */
+export function storePaidClickParams(): void {
+  storeUtmParams()
+  storeGclid()
+}
+
+export function getStoredUtmParams(): AttributionParams {
+  if (typeof window === "undefined") return {}
+  const stored = sessionStorage.getItem("utm_params")
+  if (!stored) return {}
+  try {
+    return JSON.parse(stored) as AttributionParams
+  } catch {
+    return {}
+  }
+}
+
+export function getStoredGclid(): string | undefined {
+  if (typeof window === "undefined") return undefined
+  return sessionStorage.getItem("gclid") || undefined
+}
+
+export function getStoredAttribution(): AttributionParams {
+  const utm = getStoredUtmParams()
+  const gclid = getStoredGclid()
+  return { ...utm, ...(gclid ? { gclid } : {}) }
+}
+
+export function isGTMLoaded(): boolean {
+  if (typeof window === "undefined") return false
+  return Boolean(window.dataLayer && window.google_tag_manager)
+}
+
+export function waitForGTM(callback: () => void, maxWaitMs = 5000): void {
+  if (typeof window === "undefined") return
+  const startTime = Date.now()
+  const check = () => {
+    if (isGTMLoaded()) callback()
+    else if (Date.now() - startTime < maxWaitMs) setTimeout(check, 100)
+    else callback()
+  }
+  check()
+}
+
+export function gtmEvent(eventName: string, eventData?: Record<string, unknown>): void {
+  if (typeof window === "undefined") return
+  const fire = () => {
+    const dl = (window.dataLayer = window.dataLayer || [])
+    if (eventData && Object.keys(eventData).length > 0) dl.push(eventData)
+    setTimeout(() => dl.push({ event: eventName }), 50)
+  }
+  waitForGTM(fire)
+}

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -1,0 +1,66 @@
+/** Conformance + runtime shared attribution keys (mined from CRL gtm.ts). */
+export const ATTRIBUTION_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+] as const
+
+export type AttributionParams = Partial<Record<(typeof ATTRIBUTION_KEYS)[number], string>>
+
+export interface BaseAnalyticsEvent {
+  event: string
+  timestamp?: number
+  page_path: string
+  page_title?: string
+  page_location?: string
+  session_id?: string
+  device_type?: "desktop" | "mobile" | "tablet"
+}
+
+export interface PageViewEvent extends BaseAnalyticsEvent {
+  event: "page_view"
+}
+
+export interface ServiceViewEvent extends BaseAnalyticsEvent {
+  event: "service_view"
+  service_id: string
+  service_name: string
+}
+
+export interface AreaViewEvent extends BaseAnalyticsEvent {
+  event: "area_view"
+  area_slug: string
+  area_name: string
+}
+
+export interface FunnelStepViewEvent extends BaseAnalyticsEvent {
+  event: "funnel_step_view"
+  funnel_id: string
+  step_name: string
+  step_number: number
+}
+
+export interface PhoneClickEvent extends BaseAnalyticsEvent {
+  event: "phone_click"
+  click_location: string
+}
+
+export interface ConversionLeadEvent extends BaseAnalyticsEvent {
+  event: "conversion_lead"
+  transaction_id: string
+  conversion_value: number
+  currency: string
+}
+
+export type AnalyticsEvent =
+  | PageViewEvent
+  | ServiceViewEvent
+  | AreaViewEvent
+  | FunnelStepViewEvent
+  | PhoneClickEvent
+  | ConversionLeadEvent
+
+export const CONVERSION_EVENTS = new Set(["conversion_lead", "lead_conversion", "conversion"])

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "media:register": "node scripts/media/register.mjs",
     "media:sync-site": "node scripts/media/sync-site.mjs",
     "media:publish": "node scripts/media/publish.mjs",
-    "media:validate": "node scripts/media/validate.mjs"
+    "media:validate": "node scripts/media/validate.mjs",
+    "analytics:conformance": "node scripts/analytics/conformance-check.mjs",
+    "analytics:weekly-report": "node scripts/analytics/weekly-report.mjs"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "^5.3.0",

--- a/scripts/analytics/conformance-check.mjs
+++ b/scripts/analytics/conformance-check.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/** Offline conformance against vendored analytics.tracking suite. */
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { runSuite } from "../../adapters/node/lib/conformance_runner.mjs"
+import {
+  AnalyticsTrackingProvider,
+  BrokenAnalyticsTrackingProvider,
+} from "../../lib/analytics/conformance-provider.mjs"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const vendored = path.join(root, "vendor/capabilities/analytics.tracking")
+const suitePath = path.join(vendored, "conformance/suite.json")
+
+if (!fs.existsSync(suitePath)) {
+  console.error("Missing vendored suite:", suitePath)
+  process.exit(2)
+}
+
+const suite = JSON.parse(fs.readFileSync(suitePath, "utf8"))
+
+function check(label, impl) {
+  const result = runSuite(impl, suite)
+  if (!result.passed) {
+    console.error(`${label} FAILED:`, result.failed_ids)
+    process.exit(1)
+  }
+  console.log(`${label} OK (${suite.cases.length} cases)`)
+}
+
+check("conformant", new AnalyticsTrackingProvider())
+
+const broken = runSuite(new BrokenAnalyticsTrackingProvider(), suite)
+if (broken.passed) {
+  console.error("Broken provider should FAIL suite (attribution bite missing)")
+  process.exit(1)
+}
+if (!broken.failed_ids.includes("reject-conversion-missing-attribution")) {
+  console.error("Expected reject-conversion-missing-attribution in", broken.failed_ids)
+  process.exit(1)
+}
+console.log("broken provider correctly fails attribution case")
+
+console.log("analytics.tracking offline conformance: PASS")

--- a/scripts/analytics/weekly-report.mjs
+++ b/scripts/analytics/weekly-report.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Weekly GA4 marketing report for Chris — credential-gated, real Data API pull.
+ *
+ * Required env (report fails loudly if absent):
+ *   GA4_PROPERTY_ID
+ *   GA4_DATA_API_CREDENTIALS_JSON  (service account JSON string)
+ *
+ * Optional email delivery:
+ *   WEEKLY_REPORT_EMAIL_TO, WEEKLY_REPORT_EMAIL_FROM
+ *   SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS
+ */
+import crypto from "node:crypto"
+import fs from "node:fs"
+
+const HUMAN_SETUP =
+  "HUMAN SETUP: Set GA4_PROPERTY_ID and GA4_DATA_API_CREDENTIALS_JSON (service account JSON with Analytics Data API read access on the GA4 property) to enable the weekly report."
+
+const propertyId = process.env.GA4_PROPERTY_ID?.trim()
+const credsJson = process.env.GA4_DATA_API_CREDENTIALS_JSON?.trim()
+
+if (!propertyId || !credsJson) {
+  console.error(HUMAN_SETUP)
+  process.exit(1)
+}
+
+let credentials
+try {
+  credentials = JSON.parse(credsJson)
+} catch {
+  console.error(`${HUMAN_SETUP} (GA4_DATA_API_CREDENTIALS_JSON is not valid JSON)`)
+  process.exit(1)
+}
+
+async function getAccessToken() {
+  const now = Math.floor(Date.now() / 1000)
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url")
+  const claim = Buffer.from(
+    JSON.stringify({
+      iss: credentials.client_email,
+      scope: "https://www.googleapis.com/auth/analytics.readonly",
+      aud: "https://oauth2.googleapis.com/token",
+      iat: now,
+      exp: now + 3600,
+    }),
+  ).toString("base64url")
+  const signInput = `${header}.${claim}`
+  const sign = crypto.createSign("RSA-SHA256")
+  sign.update(signInput)
+  sign.end()
+  const signature = sign.sign(credentials.private_key, "base64url")
+  const jwt = `${signInput}.${signature}`
+
+  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }),
+  })
+  if (!tokenRes.ok) {
+    throw new Error(`Token exchange failed: ${tokenRes.status} ${await tokenRes.text()}`)
+  }
+  const tokenJson = await tokenRes.json()
+  return tokenJson.access_token
+}
+
+async function runReport(accessToken) {
+  const end = new Date()
+  const start = new Date(end)
+  start.setDate(start.getDate() - 7)
+  const fmt = (d) => d.toISOString().slice(0, 10)
+
+  const body = {
+    dateRanges: [{ startDate: fmt(start), endDate: fmt(end) }],
+    dimensions: [{ name: "eventName" }],
+    metrics: [{ name: "eventCount" }],
+    orderBys: [{ desc: true, metric: { metricName: "eventCount" } }],
+    limit: 25,
+  }
+
+  const res = await fetch(
+    `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  )
+  if (!res.ok) {
+    throw new Error(`GA4 Data API failed: ${res.status} ${await res.text()}`)
+  }
+  return res.json()
+}
+
+function composeEmail(report, startLabel, endLabel) {
+  const rows = (report.rows || [])
+    .map((r) => {
+      const name = r.dimensionValues?.[0]?.value ?? "?"
+      const count = r.metricValues?.[0]?.value ?? "0"
+      return `  ${name}: ${count}`
+    })
+    .join("\n")
+
+  const lineItem = 449
+  return {
+    subject: `Cut Rates weekly analytics (${startLabel} – ${endLabel})`,
+    text: `Chris,
+
+Weekly marketing analytics summary for Cut Rates Lawn Care (${startLabel} to ${endLabel}).
+
+Top events (GA4):
+${rows || "  (no events in range)"}
+
+This report justifies the $${lineItem}/mo tracking & reporting line item: attribution capture (UTM + gclid), GTM-driven GA4/Ads/Meta events, and this automated weekly pull.
+
+— Cut Rates analytics.tracking weekly job`,
+  }
+}
+
+async function maybeSendEmail(email) {
+  const to = process.env.WEEKLY_REPORT_EMAIL_TO?.trim()
+  const from = process.env.WEEKLY_REPORT_EMAIL_FROM?.trim()
+  const host = process.env.SMTP_HOST?.trim()
+  if (!to || !host) {
+    console.log("Email not sent (WEEKLY_REPORT_EMAIL_TO / SMTP_HOST unset). Composed body:\n")
+    console.log(email.text)
+    return
+  }
+
+  // Minimal SMTP-free path: write artifact for GitHub Action mail step
+  fs.mkdirSync("artifacts", { recursive: true })
+  fs.writeFileSync(
+    "artifacts/weekly-analytics-report.json",
+    JSON.stringify({ to, from, ...email }, null, 2),
+  )
+  console.log("Report artifact written to artifacts/weekly-analytics-report.json")
+}
+
+async function main() {
+  const end = new Date()
+  const start = new Date(end)
+  start.setDate(start.getDate() - 7)
+  const token = await getAccessToken()
+  const report = await runReport(token)
+  const email = composeEmail(report, start.toISOString().slice(0, 10), end.toISOString().slice(0, 10))
+  await maybeSendEmail(email)
+  console.log("Weekly GA4 report completed.")
+}
+
+main().catch((err) => {
+  console.error(String(err.message || err))
+  process.exit(1)
+})

--- a/vendor/capabilities/analytics.tracking/agent_manifest.json
+++ b/vendor/capabilities/analytics.tracking/agent_manifest.json
@@ -1,0 +1,24 @@
+{
+  "summary": "GTM dataLayer marketing analytics with UTM/GCLID attribution capture, env-gated GA4/Ads/Meta forwarding, and weekly GA4 reporting.",
+  "may_override": [
+    { "path": "contract.inputs.event.event_prefix", "reason": "Brand-specific event naming (e.g. CutRates_service_view)" },
+    { "path": "contract.inputs.destinations", "reason": "Which platforms are wired; all IDs via env vars" },
+    { "path": "contract.inputs.funnel_steps", "reason": "Quote funnel step names per site" },
+    { "path": "providers", "reason": "Per-provider inherit-and-override (DEC-CP-0012)" },
+    { "path": "contract.outputs.weekly_report.recipient", "reason": "Report recipient email via env" }
+  ],
+  "must_pass": [
+    {
+      "requirement": "B.5 attribution floor — conversion events require utm_source or gclid",
+      "conformance_case_ids": [
+        "emit-page-view-with-attribution",
+        "emit-conversion-lead-with-attribution",
+        "reject-missing-page-path",
+        "reject-conversion-missing-id",
+        "reject-conversion-missing-value",
+        "reject-conversion-missing-attribution"
+      ]
+    }
+  ],
+  "must_not_change": ["id", "category", "conformance_suite.suite_id"]
+}

--- a/vendor/capabilities/analytics.tracking/conformance/suite.json
+++ b/vendor/capabilities/analytics.tracking/conformance/suite.json
@@ -1,0 +1,189 @@
+{
+  "suite_id": "analytics.tracking.conformance",
+  "version": "1.0.0",
+  "description": "Mined floor: GTM dataLayer events with UTM/GCLID attribution; conversion requires attribution; broken provider without attribution MUST fail",
+  "cases": [
+    {
+      "id": "emit-page-view-with-attribution",
+      "input": {
+        "event": {
+          "event": "page_view",
+          "page_path": "/",
+          "page_title": "Home"
+        },
+        "stored_attribution": {
+          "utm_source": "google",
+          "utm_medium": "cpc",
+          "utm_campaign": "spring-lawn",
+          "gclid": "CjwKCAiAtest123"
+        },
+        "destinations": { "ga4": "G-PLACEHOLDER", "google_ads": null, "meta_pixel": null }
+      },
+      "expect": {
+        "outcome": "pass",
+        "asserts": [
+          { "path": "$.datalayer_push.utm_source", "op": "eq", "value": "google" },
+          { "path": "$.datalayer_push.gclid", "op": "eq", "value": "CjwKCAiAtest123" },
+          { "path": "$.attribution_captured", "op": "eq", "value": true }
+        ]
+      },
+      "tags": ["floor", "mined:CRL_Lights_Landing/lib/gtm.ts"]
+    },
+    {
+      "id": "emit-service-view",
+      "input": {
+        "event": {
+          "event": "service_view",
+          "page_path": "/services/lawn-care",
+          "service_id": "lawn-care",
+          "service_name": "Lawn Care"
+        },
+        "stored_attribution": { "utm_source": "google", "gclid": "gclid-svc-1" }
+      },
+      "expect": {
+        "outcome": "pass",
+        "asserts": [
+          { "path": "$.datalayer_push.service_id", "op": "eq", "value": "lawn-care" },
+          { "path": "$.datalayer_push.gclid", "op": "exists" }
+        ]
+      },
+      "tags": ["floor"]
+    },
+    {
+      "id": "emit-area-view",
+      "input": {
+        "event": {
+          "event": "area_view",
+          "page_path": "/service-areas/wichita",
+          "area_slug": "wichita",
+          "area_name": "Wichita"
+        },
+        "stored_attribution": { "utm_medium": "organic" }
+      },
+      "expect": {
+        "outcome": "pass",
+        "asserts": [
+          { "path": "$.datalayer_push.area_slug", "op": "eq", "value": "wichita" }
+        ]
+      },
+      "tags": ["floor"]
+    },
+    {
+      "id": "emit-funnel-step",
+      "input": {
+        "event": {
+          "event": "funnel_step_view",
+          "page_path": "/quote",
+          "funnel_id": "quote",
+          "step_name": "contact",
+          "step_number": 3
+        },
+        "stored_attribution": { "utm_source": "facebook" }
+      },
+      "expect": {
+        "outcome": "pass",
+        "asserts": [
+          { "path": "$.datalayer_push.step_name", "op": "eq", "value": "contact" }
+        ]
+      },
+      "tags": ["floor", "mined:CRL quote funnel"]
+    },
+    {
+      "id": "emit-phone-click",
+      "input": {
+        "event": {
+          "event": "phone_click",
+          "page_path": "/contact",
+          "click_location": "header"
+        },
+        "stored_attribution": { "gclid": "gclid-phone" }
+      },
+      "expect": {
+        "outcome": "pass",
+        "asserts": [
+          { "path": "$.datalayer_push.click_location", "op": "eq", "value": "header" }
+        ]
+      },
+      "tags": ["floor"]
+    },
+    {
+      "id": "emit-conversion-lead-with-attribution",
+      "input": {
+        "event": {
+          "event": "conversion_lead",
+          "page_path": "/quote",
+          "transaction_id": "CRL-QUOTE-001",
+          "conversion_value": 149,
+          "currency": "USD"
+        },
+        "stored_attribution": {
+          "utm_source": "google",
+          "utm_medium": "cpc",
+          "gclid": "gclid-conv-99"
+        },
+        "destinations": { "ga4": "G-PLACEHOLDER", "google_ads": "AW-PLACEHOLDER", "meta_pixel": "PIXEL-PLACEHOLDER" }
+      },
+      "expect": {
+        "outcome": "pass",
+        "asserts": [
+          { "path": "$.datalayer_push.transaction_id", "op": "eq", "value": "CRL-QUOTE-001" },
+          { "path": "$.datalayer_push.gclid", "op": "exists" },
+          { "path": "$.attribution_captured", "op": "eq", "value": true },
+          { "path": "$.destinations_notified", "op": "contains", "value": "ga4" }
+        ]
+      },
+      "tags": ["floor", "conversion"]
+    },
+    {
+      "id": "reject-missing-page-path",
+      "input": {
+        "event": { "event": "page_view", "page_title": "Home" }
+      },
+      "expect": { "outcome": "reject", "error_code": "EVENT_SCHEMA_INVALID" },
+      "tags": ["floor", "negative"]
+    },
+    {
+      "id": "reject-conversion-missing-id",
+      "input": {
+        "event": {
+          "event": "conversion_lead",
+          "page_path": "/quote",
+          "conversion_value": 100,
+          "currency": "USD"
+        },
+        "stored_attribution": { "utm_source": "google" }
+      },
+      "expect": { "outcome": "reject", "error_code": "CONVERSION_ID_REQUIRED" },
+      "tags": ["floor", "negative"]
+    },
+    {
+      "id": "reject-conversion-missing-value",
+      "input": {
+        "event": {
+          "event": "conversion_lead",
+          "page_path": "/quote",
+          "transaction_id": "CRL-001",
+          "currency": "USD"
+        },
+        "stored_attribution": { "utm_source": "google" }
+      },
+      "expect": { "outcome": "reject", "error_code": "CONVERSION_VALUE_REQUIRED" },
+      "tags": ["floor", "negative"]
+    },
+    {
+      "id": "reject-conversion-missing-attribution",
+      "input": {
+        "event": {
+          "event": "conversion_lead",
+          "page_path": "/quote",
+          "transaction_id": "CRL-002",
+          "conversion_value": 200,
+          "currency": "USD"
+        },
+        "stored_attribution": {}
+      },
+      "expect": { "outcome": "reject", "error_code": "ATTRIBUTION_REQUIRED" },
+      "tags": ["floor", "negative", "biting:attribution"]
+    }
+  ]
+}

--- a/vendor/capabilities/analytics.tracking/contract/SPEC.md
+++ b/vendor/capabilities/analytics.tracking/contract/SPEC.md
@@ -1,0 +1,62 @@
+# analytics.tracking
+
+Page-level marketing analytics: GTM dataLayer events with UTM + GCLID attribution, forwarded to
+env-gated GA4, Google Ads conversion, and Meta Pixel destinations.
+
+## Mined from (Wave B.5)
+
+| Source | Path | Exhibited behavior |
+|---|---|---|
+| CRL GTM utilities | `CRL_Lights_Landing/lib/gtm.ts` | `getUtmParams`, `getGclid`, sessionStorage capture, `gtmEvent` dataLayer push |
+| CRL analytics core | `CRL_Lights_Landing/lib/analytics/core.ts` | `pushEvent` enrichment: timestamp, page context, UTM merge, session_id |
+| CRL hooks | `CRL_Lights_Landing/hooks/useAnalytics.ts` | page_view, form/funnel, phone, conversion patterns |
+| CRL standards | `CRL_Lights_Landing/docs/Analytics_Standards.md` | Event schema, required base fields, UTM auto-include, conversion params |
+| gads methodology | `gads_documentation` | GA4 via GTM, Ads conversion + gclid pass-through, Meta Pixel via GTM tags |
+
+## Operation (floor)
+
+1. **Capture attribution** — on first page load, read `utm_*` and `gclid` from URL; persist in sessionStorage for later events.
+2. **Emit event** — validate required fields; enrich with page context + stored attribution; push to `dataLayer`.
+3. **Forward destinations** — when env-configured platform IDs are set, GTM tags route to GA4 / Google Ads / Meta; when unset, no-op silently (no console spam).
+
+## Required events (floor)
+
+| Event | Required fields | Attribution |
+|---|---|---|
+| `page_view` | `page_path`, `page_title` | UTM/gclid merged when present |
+| `service_view` | `page_path`, `service_id`, `service_name` | UTM/gclid merged when present |
+| `area_view` | `page_path`, `area_slug`, `area_name` | UTM/gclid merged when present |
+| `funnel_step_view` | `page_path`, `funnel_id`, `step_name`, `step_number` | UTM/gclid merged when present |
+| `phone_click` | `page_path`, `click_location` | UTM/gclid merged when present |
+| `conversion_lead` | `page_path`, `transaction_id`, `conversion_value`, `currency` | **MUST** include `utm_source` or `gclid` (stored or inline) |
+
+## Inputs (conformance floor)
+
+| Field | Required | Notes |
+|---|---|---|
+| `event` | yes | Event payload with `event` name + required fields per taxonomy |
+| `stored_attribution` | no | Session-persisted `utm_*` + `gclid` from first touch |
+| `url_attribution` | no | Fresh URL params (simulates landing query string) |
+| `destinations` | no | `{ ga4?, google_ads?, meta_pixel? }` — null/empty → no-op for that destination |
+
+## Outputs (floor)
+
+On `pass`:
+
+- `datalayer_push` — enriched event object pushed (includes merged attribution when available)
+- `attribution_captured` — boolean; true when utm_source or gclid present on conversion events
+- `destinations_notified` — list of destination keys actually notified (env-gated; empty when IDs unset)
+
+## Hard rejects
+
+| Condition | `error_code` |
+|---|---|
+| Missing `event.event` or `event.page_path` | `EVENT_SCHEMA_INVALID` |
+| `conversion_lead` missing `transaction_id` | `CONVERSION_ID_REQUIRED` |
+| `conversion_lead` missing `conversion_value` | `CONVERSION_VALUE_REQUIRED` |
+| Conversion without utm_source **and** without gclid | `ATTRIBUTION_REQUIRED` |
+
+## Consumer overrides (agent_manifest)
+
+Projects MAY override: event name prefix (e.g. `CutRates_*`), which funnel steps fire, destination env var names, weekly report recipient.
+Projects MUST NOT drop attribution capture on conversion events or hardcode platform account IDs.

--- a/vendor/capabilities/analytics.tracking/descriptor.json
+++ b/vendor/capabilities/analytics.tracking/descriptor.json
@@ -1,0 +1,288 @@
+{
+  "id": "analytics.tracking",
+  "version": "1.0.0",
+  "name": "Analytics Tracking (Marketing)",
+  "description": "Page-level GTM dataLayer analytics with UTM/GCLID attribution, env-gated GA4/Ads/Meta destinations, and credential-gated weekly GA4 reporting.",
+  "category": "product",
+  "maturity": "production",
+  "risk_level": "medium",
+  "approval_policy": "advisory",
+  "contract": {
+    "spec": "contract/SPEC.md",
+    "schemas": [],
+    "inputs": {
+      "event": {
+        "type": "object",
+        "description": "dataLayer event payload (event name + required fields per taxonomy)"
+      },
+      "stored_attribution": {
+        "type": "object",
+        "description": "Session-persisted utm_* + gclid from first touch"
+      },
+      "url_attribution": {
+        "type": "object",
+        "description": "Fresh URL attribution params"
+      },
+      "destinations": {
+        "type": "object",
+        "description": "Env-gated platform IDs: ga4, google_ads, meta_pixel — null/empty no-ops"
+      }
+    },
+    "outputs": {
+      "datalayer_push": {
+        "type": "object",
+        "description": "Enriched event pushed to dataLayer"
+      },
+      "attribution_captured": {
+        "type": "boolean",
+        "description": "Whether utm_source or gclid is present on the event"
+      },
+      "destinations_notified": {
+        "type": "array",
+        "description": "Destination keys actually notified (empty when IDs unset)"
+      }
+    }
+  },
+  "conformance_suite": {
+    "suite_id": "analytics.tracking.conformance",
+    "version": "1.0.0",
+    "description": "Mined from CRL_Lights_Landing analytics + Analytics_Standards.md",
+    "cases": [
+      {
+        "id": "emit-page-view-with-attribution",
+        "input": {
+          "event": { "event": "page_view", "page_path": "/", "page_title": "Home" },
+          "stored_attribution": {
+            "utm_source": "google",
+            "utm_medium": "cpc",
+            "utm_campaign": "spring-lawn",
+            "gclid": "CjwKCAiAtest123"
+          },
+          "destinations": { "ga4": "G-PLACEHOLDER", "google_ads": null, "meta_pixel": null }
+        },
+        "expect": {
+          "outcome": "pass",
+          "asserts": [
+            { "path": "$.datalayer_push.utm_source", "op": "eq", "value": "google" },
+            { "path": "$.datalayer_push.gclid", "op": "eq", "value": "CjwKCAiAtest123" },
+            { "path": "$.attribution_captured", "op": "eq", "value": true }
+          ]
+        }
+      },
+      {
+        "id": "emit-service-view",
+        "input": {
+          "event": {
+            "event": "service_view",
+            "page_path": "/services/lawn-care",
+            "service_id": "lawn-care",
+            "service_name": "Lawn Care"
+          },
+          "stored_attribution": { "utm_source": "google", "gclid": "gclid-svc-1" }
+        },
+        "expect": {
+          "outcome": "pass",
+          "asserts": [
+            { "path": "$.datalayer_push.service_id", "op": "eq", "value": "lawn-care" },
+            { "path": "$.datalayer_push.gclid", "op": "exists" }
+          ]
+        }
+      },
+      {
+        "id": "emit-area-view",
+        "input": {
+          "event": {
+            "event": "area_view",
+            "page_path": "/service-areas/wichita",
+            "area_slug": "wichita",
+            "area_name": "Wichita"
+          },
+          "stored_attribution": { "utm_medium": "organic" }
+        },
+        "expect": {
+          "outcome": "pass",
+          "asserts": [{ "path": "$.datalayer_push.area_slug", "op": "eq", "value": "wichita" }]
+        }
+      },
+      {
+        "id": "emit-funnel-step",
+        "input": {
+          "event": {
+            "event": "funnel_step_view",
+            "page_path": "/quote",
+            "funnel_id": "quote",
+            "step_name": "contact",
+            "step_number": 3
+          },
+          "stored_attribution": { "utm_source": "facebook" }
+        },
+        "expect": {
+          "outcome": "pass",
+          "asserts": [{ "path": "$.datalayer_push.step_name", "op": "eq", "value": "contact" }]
+        }
+      },
+      {
+        "id": "emit-phone-click",
+        "input": {
+          "event": {
+            "event": "phone_click",
+            "page_path": "/contact",
+            "click_location": "header"
+          },
+          "stored_attribution": { "gclid": "gclid-phone" }
+        },
+        "expect": {
+          "outcome": "pass",
+          "asserts": [{ "path": "$.datalayer_push.click_location", "op": "eq", "value": "header" }]
+        }
+      },
+      {
+        "id": "emit-conversion-lead-with-attribution",
+        "input": {
+          "event": {
+            "event": "conversion_lead",
+            "page_path": "/quote",
+            "transaction_id": "CRL-QUOTE-001",
+            "conversion_value": 149,
+            "currency": "USD"
+          },
+          "stored_attribution": {
+            "utm_source": "google",
+            "utm_medium": "cpc",
+            "gclid": "gclid-conv-99"
+          },
+          "destinations": {
+            "ga4": "G-PLACEHOLDER",
+            "google_ads": "AW-PLACEHOLDER",
+            "meta_pixel": "PIXEL-PLACEHOLDER"
+          }
+        },
+        "expect": {
+          "outcome": "pass",
+          "asserts": [
+            { "path": "$.datalayer_push.transaction_id", "op": "eq", "value": "CRL-QUOTE-001" },
+            { "path": "$.datalayer_push.gclid", "op": "exists" },
+            { "path": "$.attribution_captured", "op": "eq", "value": true },
+            { "path": "$.destinations_notified", "op": "contains", "value": "ga4" }
+          ]
+        }
+      },
+      {
+        "id": "reject-missing-page-path",
+        "input": { "event": { "event": "page_view", "page_title": "Home" } },
+        "expect": { "outcome": "reject", "error_code": "EVENT_SCHEMA_INVALID" }
+      },
+      {
+        "id": "reject-conversion-missing-id",
+        "input": {
+          "event": {
+            "event": "conversion_lead",
+            "page_path": "/quote",
+            "conversion_value": 100,
+            "currency": "USD"
+          },
+          "stored_attribution": { "utm_source": "google" }
+        },
+        "expect": { "outcome": "reject", "error_code": "CONVERSION_ID_REQUIRED" }
+      },
+      {
+        "id": "reject-conversion-missing-value",
+        "input": {
+          "event": {
+            "event": "conversion_lead",
+            "page_path": "/quote",
+            "transaction_id": "CRL-001",
+            "currency": "USD"
+          },
+          "stored_attribution": { "utm_source": "google" }
+        },
+        "expect": { "outcome": "reject", "error_code": "CONVERSION_VALUE_REQUIRED" }
+      },
+      {
+        "id": "reject-conversion-missing-attribution",
+        "input": {
+          "event": {
+            "event": "conversion_lead",
+            "page_path": "/quote",
+            "transaction_id": "CRL-002",
+            "conversion_value": 200,
+            "currency": "USD"
+          },
+          "stored_attribution": {}
+        },
+        "expect": { "outcome": "reject", "error_code": "ATTRIBUTION_REQUIRED" }
+      }
+    ]
+  },
+  "reference_implementation": {
+    "language": "typescript",
+    "path": "lib/analytics/",
+    "repository": "xoate0100/CutRatesLawnWebSite",
+    "notes": "CutRates marketing site provider; env-gated platform IDs; conformance via lib/analytics/conformance-provider.mjs"
+  },
+  "providers": [
+    {
+      "id": "hub-analytics-fixture",
+      "repo": "xoate0100/project_initializer",
+      "path": "backend/capability_adapter/impls_analytics.py",
+      "language": "python",
+      "tag": "main",
+      "conformance_status": "pass",
+      "conformance_evidence": "tests/test_analytics_tracking_conformance.py::test_conformant_passes",
+      "exceeds_floor": [],
+      "notes": "Fixture-based provider for registry gate + hub tests"
+    },
+    {
+      "id": "cutrateslawn-analytics",
+      "repo": "xoate0100/CutRatesLawnWebSite",
+      "path": "lib/analytics/",
+      "language": "typescript",
+      "tag": "main",
+      "conformance_status": "pending",
+      "conformance_evidence": "scripts/analytics/conformance-check.mjs",
+      "exceeds_floor": ["weekly_ga4_report", "quote_funnel_steps", "service_area_bindings"],
+      "notes": "Production GTM + env-gated GA4/Ads/Meta; weekly report credential-gated"
+    }
+  ],
+  "agent_manifest": {
+    "summary": "GTM dataLayer marketing analytics with UTM/GCLID attribution capture, env-gated GA4/Ads/Meta forwarding, and weekly GA4 reporting.",
+    "may_override": [
+      { "path": "contract.inputs.event.event_prefix", "reason": "Brand-specific event naming (e.g. CutRates_service_view)" },
+      { "path": "contract.inputs.destinations", "reason": "Which platforms are wired; all IDs via env vars" },
+      { "path": "contract.inputs.funnel_steps", "reason": "Quote funnel step names per site" },
+      { "path": "providers", "reason": "Per-provider inherit-and-override (DEC-CP-0012)" },
+      { "path": "contract.outputs.weekly_report.recipient", "reason": "Report recipient email via env" }
+    ],
+    "must_pass": [
+      {
+        "requirement": "B.5 attribution floor — conversion events require utm_source or gclid",
+        "conformance_case_ids": [
+          "emit-page-view-with-attribution",
+          "emit-conversion-lead-with-attribution",
+          "reject-missing-page-path",
+          "reject-conversion-missing-id",
+          "reject-conversion-missing-value",
+          "reject-conversion-missing-attribution"
+        ]
+      }
+    ],
+    "must_not_change": ["id", "category", "conformance_suite.suite_id"]
+  },
+  "dependencies": [],
+  "evaluators": ["EV.schema.capability_registry"],
+  "provenance": {
+    "reference_repos": [
+      "xoate0100/CRL_Lights_Landing",
+      "xoate0100/CutRatesLawnWebSite",
+      "xoate0100/gads_documentation"
+    ],
+    "mined_sources": [
+      "CRL_Lights_Landing/lib/gtm.ts",
+      "CRL_Lights_Landing/lib/analytics/core.ts",
+      "CRL_Lights_Landing/hooks/useAnalytics.ts",
+      "CRL_Lights_Landing/docs/Analytics_Standards.md",
+      "gads_documentation"
+    ],
+    "first_registration_gate": "initial_registration — agent.reviewer.capability_bump + conformance green"
+  }
+}


### PR DESCRIPTION
## Summary
- Vendors analytics.tracking@v1.0.0 (CAPABILITIES.lock + vendor/)
- GTM dataLayer tracking: page_view, service_view, area_view, funnel steps, phone_click, conversion_lead
- All platform IDs env-gated (NEXT_PUBLIC_GTM_CONTAINER_ID, GA4, Ads, Meta) — no-op when unset
- Weekly GA4 report script + GitHub Action (credential-gated; fails with HUMAN SETUP callout when unset)

## Human setup (Andy)
See project_initializer docs/factory/ANALYTICS_TRACKING_REPORT.md — GA4 property, GTM container, Ads conversion, Meta Pixel, GA4 Data API service account.

## Test plan
- [x] node scripts/analytics/conformance-check.mjs
- [x] pnpm build (zero analytics env vars)
- [x] node scripts/analytics/weekly-report.mjs → credential callout when unset